### PR TITLE
Add CW client extension traits

### DIFF
--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -198,9 +198,9 @@ where
 }
 
 pub trait CwClientValidation<'a>: ClientValidationContext {
-    fn cosmwasm_query_context(&self) -> Option<&Deps<'a>>;
-    fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>>;
-    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum;
+    fn deps(&self) -> Option<&Deps<'a>>;
+    fn deps_mut(&mut self) -> Option<&mut DepsMut<'a>>;
+    fn checksum(&self, data: &[u8]) -> Checksum;
 }
 
 pub trait CwClientExecution<'a>: CwClientValidation<'a> + ClientExecutionContext {}
@@ -210,15 +210,15 @@ where
     <C::ClientState as TryFrom<Any>>::Error: Display,
     <C::ConsensusState as TryFrom<Any>>::Error: Display,
 {
-    fn cosmwasm_query_context(&self) -> Option<&Deps<'a>> {
+    fn deps(&self) -> Option<&Deps<'a>> {
         self.deps.as_ref()
     }
 
-    fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>> {
+    fn deps_mut(&mut self) -> Option<&mut DepsMut<'a>> {
         self.deps_mut.as_mut()
     }
 
-    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum {
+    fn checksum(&self, data: &[u8]) -> Checksum {
         Checksum::generate(data)
     }
 }

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -2,6 +2,7 @@
 //! traits for the `Context` type.
 use core::fmt::Display;
 
+use cosmwasm_std::{Deps, DepsMut};
 use ibc_client_wasm_types::client_state::ClientState as WasmClientState;
 use ibc_client_wasm_types::consensus_state::ConsensusState as WasmConsensusState;
 use ibc_core::client::context::{ClientExecutionContext, ClientValidationContext};
@@ -193,5 +194,26 @@ where
         );
 
         Ok(())
+    }
+}
+
+pub trait CwClientValidation: ClientValidationContext {
+    fn cosmwasm_query_context(&self) -> Option<Deps<'_>>;
+    fn cosmwasm_execute_context(&self) -> Option<DepsMut<'_>>;
+}
+
+pub trait CwClientExecution: CwClientValidation + ClientExecutionContext {}
+
+impl<'a, C: ClientType<'a>> CwClientValidation for Context<'a, C>
+where
+    <C::ClientState as TryFrom<Any>>::Error: Display,
+    <C::ConsensusState as TryFrom<Any>>::Error: Display,
+{
+    fn cosmwasm_query_context(&self) -> Option<Deps<'_>> {
+        self.deps
+    }
+
+    fn cosmwasm_execute_context(&self) -> Option<DepsMut<'_>> {
+        None
     }
 }

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -198,7 +198,7 @@ where
 }
 
 pub trait CwClientValidation<'a>: ClientValidationContext {
-    fn cosmwasm_query_context(&self) -> Option<Deps<'_>>;
+    fn cosmwasm_query_context(&self) -> Option<&Deps<'a>>;
     fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>>;
 }
 
@@ -209,8 +209,8 @@ where
     <C::ClientState as TryFrom<Any>>::Error: Display,
     <C::ConsensusState as TryFrom<Any>>::Error: Display,
 {
-    fn cosmwasm_query_context(&self) -> Option<Deps<'_>> {
-        self.deps
+    fn cosmwasm_query_context(&self) -> Option<&Deps<'a>> {
+        self.deps.as_ref()
     }
 
     fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>> {

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -200,7 +200,7 @@ where
 pub trait CwClientValidation<'a>: ClientValidationContext {
     fn cosmwasm_query_context(&self) -> Option<&Deps<'a>>;
     fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>>;
-    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum;
+    fn generate_sha256_digest(&mut self, data: &[u8]) -> Checksum;
 }
 
 pub trait CwClientExecution<'a>: CwClientValidation<'a> + ClientExecutionContext {}
@@ -218,7 +218,7 @@ where
         self.deps_mut.as_mut()
     }
 
-    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum {
+    fn generate_sha256_digest(&mut self, data: &[u8]) -> Checksum {
         Checksum::generate(data)
     }
 }

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -200,7 +200,7 @@ where
 pub trait CwClientValidation<'a>: ClientValidationContext {
     fn cosmwasm_query_context(&self) -> Option<&Deps<'a>>;
     fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>>;
-    fn generate_sha256_digest(&mut self, data: &[u8]) -> Checksum;
+    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum;
 }
 
 pub trait CwClientExecution<'a>: CwClientValidation<'a> + ClientExecutionContext {}
@@ -218,7 +218,7 @@ where
         self.deps_mut.as_mut()
     }
 
-    fn generate_sha256_digest(&mut self, data: &[u8]) -> Checksum {
+    fn generate_sha256_digest(&self, data: &[u8]) -> Checksum {
         Checksum::generate(data)
     }
 }

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -217,3 +217,10 @@ where
         None
     }
 }
+
+impl<'a, C: ClientType<'a>> CwClientExecution for Context<'a, C>
+where
+    <C::ClientState as TryFrom<Any>>::Error: Display,
+    <C::ConsensusState as TryFrom<Any>>::Error: Display,
+{
+}

--- a/ibc-clients/cw-context/src/context/client_ctx.rs
+++ b/ibc-clients/cw-context/src/context/client_ctx.rs
@@ -197,14 +197,14 @@ where
     }
 }
 
-pub trait CwClientValidation: ClientValidationContext {
+pub trait CwClientValidation<'a>: ClientValidationContext {
     fn cosmwasm_query_context(&self) -> Option<Deps<'_>>;
-    fn cosmwasm_execute_context(&self) -> Option<DepsMut<'_>>;
+    fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>>;
 }
 
-pub trait CwClientExecution: CwClientValidation + ClientExecutionContext {}
+pub trait CwClientExecution<'a>: CwClientValidation<'a> + ClientExecutionContext {}
 
-impl<'a, C: ClientType<'a>> CwClientValidation for Context<'a, C>
+impl<'a, C: ClientType<'a>> CwClientValidation<'a> for Context<'a, C>
 where
     <C::ClientState as TryFrom<Any>>::Error: Display,
     <C::ConsensusState as TryFrom<Any>>::Error: Display,
@@ -213,12 +213,12 @@ where
         self.deps
     }
 
-    fn cosmwasm_execute_context(&self) -> Option<DepsMut<'_>> {
-        None
+    fn cosmwasm_execute_context(&mut self) -> Option<&mut DepsMut<'a>> {
+        self.deps_mut.as_mut()
     }
 }
 
-impl<'a, C: ClientType<'a>> CwClientExecution for Context<'a, C>
+impl<'a, C: ClientType<'a>> CwClientExecution<'a> for Context<'a, C>
 where
     <C::ClientState as TryFrom<Any>>::Error: Display,
     <C::ConsensusState as TryFrom<Any>>::Error: Display,

--- a/ibc-clients/ics07-tendermint/src/client_type.rs
+++ b/ibc-clients/ics07-tendermint/src/client_type.rs
@@ -6,7 +6,7 @@ use ibc_client_tendermint::consensus_state::ConsensusState;
 #[derive(Clone, Debug)]
 pub struct TendermintClient;
 
-impl<'a> ClientType<'a> for TendermintClient {
+impl ClientType<'_> for TendermintClient {
     type ClientState = ClientState;
     type ConsensusState = ConsensusState;
 }


### PR DESCRIPTION
This PR adds `CwClientValidation` and `CwClientExecution` traits allowing to retrieve `Deps` and `DepsMut` from `Context